### PR TITLE
import from correct rxjs modules to reduce final bundle size

### DIFF
--- a/src/calendar.service.ts
+++ b/src/calendar.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
-import { Subject, Observable } from 'rxjs/Rx';
+import { Observable } from "rxjs/Observable";
+import { Subject} from "rxjs/Subject";
 
 import { ICalendarComponent, IView, CalendarMode, QueryMode } from './calendar';
 

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Input, OnInit, Output, TemplateRef, Inject, LOCALE_ID } from '@angular/core';
-import { Subscription } from 'rxjs/Rx';
+import { Subscription } from 'rxjs/Subscription';
 
 import { CalendarService } from './calendar.service';
 

--- a/src/dayview.ts
+++ b/src/dayview.ts
@@ -1,7 +1,7 @@
 import { DatePipe } from '@angular/common';
 import { Slides } from 'ionic-angular';
 import { Component, OnInit, OnChanges, HostBinding, Input, Output, EventEmitter, SimpleChanges, ViewChild, ViewEncapsulation, TemplateRef } from '@angular/core';
-import { Subscription } from 'rxjs/Rx';
+import { Subscription } from 'rxjs/Subscription';
 
 import { ICalendarComponent, IDayView, IDayViewRow, IDisplayEvent, IEvent, ITimeSelected, IRange, CalendarMode } from './calendar';
 import { CalendarService } from './calendar.service';

--- a/src/monthview.ts
+++ b/src/monthview.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnChanges, Input, Output, EventEmitter, SimpleChanges, ViewChild, TemplateRef } from '@angular/core';
-import { Subscription } from 'rxjs/Rx';
+import { Subscription } from 'rxjs/Subscription';
 import { DatePipe } from '@angular/common';
 import { Slides } from 'ionic-angular';
 

--- a/src/weekview.ts
+++ b/src/weekview.ts
@@ -1,7 +1,7 @@
 import { DatePipe } from '@angular/common';
 import { Slides } from 'ionic-angular';
 import { Component, OnInit, OnChanges, HostBinding, Input, Output, EventEmitter, SimpleChanges, ViewChild, ViewEncapsulation, TemplateRef } from '@angular/core';
-import { Subscription } from 'rxjs/Rx';
+import { Subscription } from 'rxjs/Subscription';
 
 import { ICalendarComponent, IDisplayEvent, IEvent, ITimeSelected, IRange, IWeekView, IWeekViewRow, IWeekViewDateRow, CalendarMode } from './calendar';
 import { CalendarService } from './calendar.service';


### PR DESCRIPTION
Hi,
I found out that after including your calendar, which I like a lot, in the final js bundle, the total rxjs library was included. After importing the needed rxjs classes from the submodules only the needed parts of rxjs are imported to the bundle. This saved me 198kB in the final bundle.

Thanks a lot for your component.