### PR TITLE
Add lockSwipeToNext option

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,22 +189,24 @@ Default value: 0
 If set to true, the previous/next views in weekview and dayview will also scroll to the same position as the current active view.  
 Default value: false
 
-* lockSwipeToPrev  
-If set to true, swiping to previous view is disabled.  
+* lockSwipeToPrev/lockSwipeToNext
+If set to true, swiping to previous/next view will be disabled. Useful for bounded date ranges.
 Default value: false
 
-        <calendar ... [lockSwipeToPrev]=“lockSwipeToPrev”></calendar>
+        <calendar ... [lockSwipeToPrev]=“lockSwipeToPrev” [lockSwipeToNext]=lockSwipeToNext></calendar>
 
         onCurrentDateChanged(event:Date) {
             var today = new Date();
             today.setHours(0, 0, 0, 0);
             event.setHours(0, 0, 0, 0);
-    
+
             if (this.calendar.mode === 'month') {
                 if (event.getFullYear() < today.getFullYear() || (event.getFullYear() === today.getFullYear() && event.getMonth() <= today.getMonth())) {
                     this.lockSwipeToPrev = true;
-                } else {
-                    this.lockSwipeToPrev = false;
+                }
+
+                if (event.getFullYear() > today.getFullYear() || (event.getFullYear() === today.getFullYear() && event.getMonth() >= today.getMonth())) {
+                    this.lockSwipeToNext = true;
                 }
             }
         }
@@ -302,7 +304,7 @@ Type: TemplateRef\<IMonthViewEventDetailTemplateContext\>
 The template provides customized view for event detail section in the monthview
 
         <template #template let-showEventDetail="showEventDetail" let-selectedDate="selectedDate" let-noEventsLabel="noEventsLabel">
-	    ... 
+	    ...
         </template>
 
         <calendar ... [monthviewEventDetailTemplate]="template"></calendar>

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -171,6 +171,7 @@ export enum Step {
                 [dateFormatter]="dateFormatter"
                 [dir]="dir"
                 [lockSwipeToPrev]="lockSwipeToPrev"
+                [lockSwipeToNext]="lockSwipeToNext"
                 [lockSwipes]="lockSwipes"
                 (onRangeChanged)="rangeChanged($event)"
                 (onEventSelected)="eventSelected($event)"
@@ -194,6 +195,7 @@ export enum Step {
                 [scrollToHour]="scrollToHour"
                 [preserveScrollPosition]="preserveScrollPosition"
                 [lockSwipeToPrev]="lockSwipeToPrev"
+                [lockSwipeToNext]="lockSwipeToNext"
                 [lockSwipes]="lockSwipes"
                 (onRangeChanged)="rangeChanged($event)"
                 (onEventSelected)="eventSelected($event)"
@@ -215,6 +217,7 @@ export enum Step {
                 [scrollToHour]="scrollToHour"
                 [preserveScrollPosition]="preserveScrollPosition"
                 [lockSwipeToPrev]="lockSwipeToPrev"
+                [lockSwipeToNext]="lockSwipeToNext"
                 [lockSwipes]="lockSwipes"
                 (onRangeChanged)="rangeChanged($event)"
                 (onEventSelected)="eventSelected($event)"
@@ -311,6 +314,7 @@ export class CalendarComponent implements OnInit {
     @Input() scrollToHour:number = 0;
     @Input() preserveScrollPosition:boolean = false;
     @Input() lockSwipeToPrev:boolean = false;
+    @Input() lockSwipeToNext:boolean = true;
     @Input() lockSwipes:boolean = false;
 
     @Output() onCurrentDateChanged = new EventEmitter<Date>();

--- a/src/dayview.ts
+++ b/src/dayview.ts
@@ -392,6 +392,7 @@ export class DayViewComponent implements ICalendarComponent, OnInit, OnChanges {
     @Input() scrollToHour:number = 0;
     @Input() preserveScrollPosition:boolean;
     @Input() lockSwipeToPrev:boolean;
+    @Input() lockSwipeToNext: boolean;
     @Input() lockSwipes:boolean;
 
     @Output() onRangeChanged = new EventEmitter<IRange>();
@@ -444,6 +445,10 @@ export class DayViewComponent implements ICalendarComponent, OnInit, OnChanges {
             this.slider.lockSwipeToPrev(true);
         }
 
+        if (this.lockSwipeToNext) {
+          this.slider.lockSwipeToNext(true);
+        }
+
         if (this.lockSwipes) {
             this.slider.lockSwipes(true);
         }
@@ -486,6 +491,11 @@ export class DayViewComponent implements ICalendarComponent, OnInit, OnChanges {
         let lockSwipeToPrev = changes['lockSwipeToPrev'];
         if (lockSwipeToPrev) {
             this.slider.lockSwipeToPrev(lockSwipeToPrev.currentValue);
+        }
+
+        let lockSwipeToNext = changes['lockSwipeToNext'];
+        if (lockSwipeToNext) {
+            this.slider.lockSwipeToNext(lockSwipeToNext.currentValue);
         }
 
         let lockSwipes = changes['lockSwipes'];

--- a/src/monthview.ts
+++ b/src/monthview.ts
@@ -245,6 +245,7 @@ export class MonthViewComponent implements ICalendarComponent, OnInit, OnChanges
     @Input() dateFormatter:IDateFormatter;
     @Input() dir:string = "";
     @Input() lockSwipeToPrev:boolean;
+    @Input() lockSwipeToNext:boolean;
     @Input() lockSwipes:boolean;
 
     @Output() onRangeChanged = new EventEmitter<IRange>();
@@ -303,6 +304,10 @@ export class MonthViewComponent implements ICalendarComponent, OnInit, OnChanges
             this.slider.lockSwipeToPrev(true);
         }
 
+        if (this.lockSwipeToNext) {
+            this.slider.lockSwipeToNext(true);
+        }
+
         if (this.lockSwipes) {
             this.slider.lockSwipes(true);
         }
@@ -342,6 +347,11 @@ export class MonthViewComponent implements ICalendarComponent, OnInit, OnChanges
         let lockSwipeToPrev = changes['lockSwipeToPrev'];
         if (lockSwipeToPrev) {
             this.slider.lockSwipeToPrev(lockSwipeToPrev.currentValue);
+        }
+
+        let lockSwipeToNext = changes['lockSwipeToNext'];
+        if (lockSwipeToNext) {
+            this.slider.lockSwipeToNext(lockSwipeToNext.currentValue);
         }
 
         let lockSwipes = changes['lockSwipes'];

--- a/src/weekview.ts
+++ b/src/weekview.ts
@@ -478,6 +478,7 @@ export class WeekViewComponent implements ICalendarComponent, OnInit, OnChanges 
     @Input() scrollToHour:number = 0;
     @Input() preserveScrollPosition:boolean;
     @Input() lockSwipeToPrev:boolean;
+    @Input() lockSwipeToNext:boolean;
     @Input() lockSwipes:boolean;
 
     @Output() onRangeChanged = new EventEmitter<IRange>();
@@ -536,6 +537,10 @@ export class WeekViewComponent implements ICalendarComponent, OnInit, OnChanges 
             this.slider.lockSwipeToPrev(true);
         }
 
+        if (this.lockSwipeToNext) {
+            this.slider.lockSwipeToNext(true);
+        }
+
         if (this.lockSwipes) {
             this.slider.lockSwipes(true);
         }
@@ -577,6 +582,11 @@ export class WeekViewComponent implements ICalendarComponent, OnInit, OnChanges 
         let lockSwipeToPrev = changes['lockSwipeToPrev'];
         if (lockSwipeToPrev) {
             this.slider.lockSwipeToPrev(lockSwipeToPrev.currentValue);
+        }
+
+        let lockSwipeToNext = changes['lockSwipeToNext'];
+        if (lockSwipeToNext) {
+            this.slider.lockSwipeToNext(lockSwipeToNext.currentValue);
         }
 
         let lockSwipes = changes['lockSwipesv'];


### PR DESCRIPTION
Hi @twinssbc, thanks for the wonderful plugin.

With reference to #132, what exactly was the problem you faced when trying out `lockSwipeToNext`? I tried to expose `lockSwipeToNext` exactly how `lockSwipeToPrev` was implemented and found no problems with it so far. 

I'm working on a project where I need to scope the swiping to a certain date range and `lockSwipes` just doesn't work well when user swipes to the boundary dates and wants to swipe back to the previous date. With `lockSwipeToPrev` and `lockSwipeToNext` I can easily check if the next date to be swiped is within the range ex.

```
onCurrentDateChanged(currentDate: Date) {
    // allow swipe if date falls within [23, 28]
    this.calendar.lockSwipeToPrev = currentDate.getDate() <= 23;
    this.calendar.lockSwipeToNext = currentDate.getDate() >= 28;
}

```