### PR TITLE
Fixed typo for lockSwipes in weekview.ts

### DIFF
--- a/src/weekview.ts
+++ b/src/weekview.ts
@@ -585,7 +585,7 @@ export class WeekViewComponent implements ICalendarComponent, OnInit, OnChanges 
             this.slider.lockSwipeToPrev(lockSwipeToPrev.currentValue);
         }
 
-        let lockSwipes = changes['lockSwipesv'];
+        let lockSwipes = changes['lockSwipes'];
         if (lockSwipes) {
             this.slider.lockSwipes(lockSwipes.currentValue);
         }


### PR DESCRIPTION
Locking the swipe action is not working in the week view due to a wrong name in `changes` dictionary (in `ngOnChanges`) for `lockSwipe` variable. I've fixed it :-)