### PR TITLE
Updating the ion-slides of the month, day and week view from the calendar.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "ionic2-calendar",
-    "version": "0.6.3",
+    "version": "0.6.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/calendar.service.ts
+++ b/src/calendar.service.ts
@@ -10,18 +10,21 @@ export class CalendarService {
     currentDateChangedFromChildren$: Observable<Date>;
     eventSourceChanged$: Observable<void>;
     slideChanged$: Observable<number>;
+    slideUpdated$: Observable<void>;
 
     private _currentDate: Date;
     private currentDateChangedFromParent = new Subject<Date>();
     private currentDateChangedFromChildren = new Subject<Date>();
     private eventSourceChanged = new Subject<void>();
     private slideChanged = new Subject<number>();
+    private slideUpdated = new Subject<void>();
 
     constructor() {
         this.currentDateChangedFromParent$ = this.currentDateChangedFromParent.asObservable();
         this.currentDateChangedFromChildren$ = this.currentDateChangedFromChildren.asObservable();
         this.eventSourceChanged$ = this.eventSourceChanged.asObservable();
         this.slideChanged$ = this.slideChanged.asObservable();
+        this.slideUpdated$ = this.slideUpdated.asObservable();
     }
 
     setCurrentDate(val: Date, fromParent: boolean = false) {
@@ -151,5 +154,9 @@ export class CalendarService {
 
     slide(direction: number) {
         this.slideChanged.next(direction);
+    }
+
+    update() {
+        this.slideUpdated.next();
     }
 }

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -488,4 +488,8 @@ export class CalendarComponent implements OnInit {
     slidePrev() {
         this.calendarService.slide(-1);
     }
+
+    update() {
+        this.calendarService.update();
+    }
 }

--- a/src/dayview.ts
+++ b/src/dayview.ts
@@ -446,6 +446,7 @@ export class DayViewComponent implements ICalendarComponent, OnInit, OnChanges, 
     private currentDateChangedFromParentSubscription: Subscription;
     private eventSourceChangedSubscription: Subscription;
     private slideChangedSubscription: Subscription;
+    private slideUpdatedSubscription: Subscription;
 
     public hourColumnLabels: string[];
     public initScrollPosition: number;
@@ -595,6 +596,10 @@ export class DayViewComponent implements ICalendarComponent, OnInit, OnChanges, 
                 this.slider.slidePrev();
             }
         });
+
+        this.slideUpdatedSubscription = this.calendarService.slideUpdated$.subscribe(() => {
+            this.slider.update();
+        });
     }
 
     ngAfterViewInit() {
@@ -645,6 +650,11 @@ export class DayViewComponent implements ICalendarComponent, OnInit, OnChanges, 
         if (this.slideChangedSubscription) {
             this.slideChangedSubscription.unsubscribe();
             this.slideChangedSubscription = null;
+        }
+
+        if (this.slideUpdatedSubscription) {
+            this.slideUpdatedSubscription.unsubscribe();
+            this.slideUpdatedSubscription = null;
         }
     }
 

--- a/src/monthview.ts
+++ b/src/monthview.ts
@@ -734,6 +734,10 @@ export class MonthViewComponent implements ICalendarComponent, OnInit, OnDestroy
         }
     }
 
+    updateSize() {
+        this.slider.update();
+    }
+
     updateCurrentView(currentViewStartDate: Date, view: IMonthView) {
         const currentCalendarDate = this.calendarService.currentDate,
             today = new Date(),

--- a/src/monthview.ts
+++ b/src/monthview.ts
@@ -284,6 +284,7 @@ export class MonthViewComponent implements ICalendarComponent, OnInit, OnDestroy
     private currentDateChangedFromParentSubscription: Subscription;
     private eventSourceChangedSubscription: Subscription;
     private slideChangedSubscription: Subscription;
+    private slideUpdatedSubscription: Subscription;
 
     private formatDayLabel: (date: Date) => string;
     private formatDayHeaderLabel: (date: Date) => string;
@@ -359,6 +360,10 @@ export class MonthViewComponent implements ICalendarComponent, OnInit, OnDestroy
                 this.slider.slidePrev();
             }
         });
+
+        this.slideUpdatedSubscription = this.calendarService.slideUpdated$.subscribe(() => {
+            this.slider.update();
+        });
     }
 
     ngOnDestroy() {
@@ -375,6 +380,11 @@ export class MonthViewComponent implements ICalendarComponent, OnInit, OnDestroy
         if (this.slideChangedSubscription) {
             this.slideChangedSubscription.unsubscribe();
             this.slideChangedSubscription = null;
+        }
+
+        if (this.slideUpdatedSubscription) {
+            this.slideUpdatedSubscription.unsubscribe();
+            this.slideUpdatedSubscription = null;
         }
     }
 
@@ -732,10 +742,6 @@ export class MonthViewComponent implements ICalendarComponent, OnInit, OnDestroy
         } else if (direction === -1) {
             this.slider.slidePrev();
         }
-    }
-
-    updateSize() {
-        this.slider.update();
     }
 
     updateCurrentView(currentViewStartDate: Date, view: IMonthView) {

--- a/src/weekview.ts
+++ b/src/weekview.ts
@@ -555,6 +555,7 @@ export class WeekViewComponent implements ICalendarComponent, OnInit, OnChanges,
     private currentDateChangedFromParentSubscription: Subscription;
     private eventSourceChangedSubscription: Subscription;
     private slideChangedSubscription: Subscription;
+    private slideUpdatedSubscription: Subscription;
 
     public hourColumnLabels: string[];
     public initScrollPosition: number;
@@ -731,6 +732,10 @@ export class WeekViewComponent implements ICalendarComponent, OnInit, OnChanges,
                 this.slider.slidePrev();
             }
         });
+
+        this.slideUpdatedSubscription = this.calendarService.slideUpdated$.subscribe(() => {
+            this.slider.update();
+        });
     }
 
     ngAfterViewInit() {
@@ -781,6 +786,11 @@ export class WeekViewComponent implements ICalendarComponent, OnInit, OnChanges,
         if (this.slideChangedSubscription) {
             this.slideChangedSubscription.unsubscribe();
             this.slideChangedSubscription = null;
+        }
+
+        if (this.slideUpdatedSubscription) {
+            this.slideUpdatedSubscription.unsubscribe();
+            this.slideUpdatedSubscription = null;
         }
     }
 


### PR DESCRIPTION
This pull request adds the functionality to update the ion-slides inside the month, day and week views so that whenever the size of the container changes, the user can manually call the update function on the calendar to update the size of the slides inside the views.

I haven't been able to test this in the demo yet, but I assume this is what needs to be done.

In other words, I haven't tested this yet.
I'm trying to build a test case where I can actually deploy an app to a mobile device and test it from there with for example screen orientation changes.

I'm a bit too lazy to alter the demo code for this use-case.