### PR TITLE
fix: dayview and monthview to correcly handle startHour and andHour 

### DIFF
--- a/src/dayview.ts
+++ b/src/dayview.ts
@@ -619,6 +619,13 @@ export class DayViewComponent implements ICalendarComponent, OnInit, OnChanges, 
         if (!this.inited) {
             return;
         }
+        if ((changes.startHour || changes.endHour) && (!changes.startHour.isFirstChange() || !changes.endHour.isFirstChange())) {
+            this.views = undefined;
+            this.hourRange = (this.endHour - this.startHour) * this.hourSegments;
+            this.direction = 0;
+            this.refreshView();
+            this.hourColumnLabels = this.getHourColumnLabels();
+        }
 
         const eventSourceChange = changes.eventSource;
         if (eventSourceChange && eventSourceChange.currentValue) {

--- a/src/weekview.ts
+++ b/src/weekview.ts
@@ -756,6 +756,14 @@ export class WeekViewComponent implements ICalendarComponent, OnInit, OnChanges,
             return;
         }
 
+        if ((changes.startHour || changes.endHour) && (!changes.startHour.isFirstChange() || !changes.endHour.isFirstChange())) {
+            this.views = undefined;
+            this.hourRange = (this.endHour - this.startHour) * this.hourSegments;
+            this.direction = 0;
+            this.refreshView();
+            this.hourColumnLabels = this.getHourColumnLabels();
+        }
+
         const eventSourceChange = changes.eventSource;
         if (eventSourceChange && eventSourceChange.currentValue) {
             this.onDataLoaded();


### PR DESCRIPTION
This PR fixes/implements changing of startHour and endHour calendar properties at runtime.

### Issue:
When you set [startHour] or [endHour] at runtime (ie. based on user interaction), Calendar does not re-render. Even if you force re-rendering (ie. by updating [currentDate]) calendar fails when swtiching from shorter time range (ie 8-16) to longer range (ie 0-24)