### PR TITLE
Extend Ionic2-Calender to display recurring events.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "2.5.0",
             "license": "MIT",
             "dependencies": {
+                "moment-recur-ts": "^1.3.1",
                 "tslib": "^2.3.0"
             },
             "devDependencies": {
@@ -8574,6 +8575,26 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/moment": {
+            "version": "2.30.1",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+            "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+            "peer": true,
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/moment-recur-ts": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/moment-recur-ts/-/moment-recur-ts-1.3.1.tgz",
+            "integrity": "sha512-jfQMlPSs5s/WAfRZn/KONRYTaHNxDFPcz5GL1YOm0fAxgASPAtWEGlmdK+mDV4fks1dbr+rNZGqQNZIfK4HDXA==",
+            "engines": {
+                "node": ">=6.0.0"
+            },
+            "peerDependencies": {
+                "moment": "^2.13.0"
             }
         },
         "node_modules/mrmime": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "build": "rm -rf dist && ng build"
     },
     "dependencies": {
+        "moment-recur-ts": "^1.3.1",
         "tslib": "^2.3.0"
     },
     "peerDependencies": {

--- a/src/calendar.interface.ts
+++ b/src/calendar.interface.ts
@@ -1,11 +1,24 @@
 import { EventEmitter, TemplateRef } from '@angular/core';
+import 'moment-recur-ts'
+import { Rule } from 'moment-recur-ts';
 
+export interface IOccurence {
+    eventUTCStartTime: number;
+    eventUTCEndTime: number;
+}
+
+export interface IOccurences {
+
+}
 export interface IEvent  {
     allDay: boolean;
     endTime: Date;
     startTime: Date;
     title: string;
     category?: string;
+    rruleFreq?: Rule.MeasureInput;
+    rruleInterval?: Rule.UnitsInput;
+    rruleUntil?: Date;
 }
 
 export interface IRange {

--- a/src/calendar.service.ts
+++ b/src/calendar.service.ts
@@ -188,17 +188,13 @@ export class CalendarService {
         if(event.rruleUntil && event.rruleUntil.getTime() < utcStartTime ){
             return occurences;
         }
-        let time = utcStartTime + 1
-        let oneDay = 86400000
-        let recurrence = moment(event.startTime.getDate()).recur().every(event.rruleInterval, event.rruleFreq)
-        while (time < utcEndTime + 1) {
-            if(recurrence.matches(time)) {
-                occurences.push({
-                    eventUTCStartTime: time,
-                    eventUTCEndTime: time + oneDay -2
-                })
-            }
-            time += oneDay
+        for( let match of moment(event.startTime.getDate()).recur(utcStartTime,utcEndTime).every(event.rruleInterval, event.rruleFreq).all('L') ){
+            let matchDate = new Date(match)
+            let eventUTCStartTime = Date.UTC(matchDate.getFullYear(), matchDate.getMonth(), matchDate.getDate())
+            occurences.push({
+                eventUTCStartTime: eventUTCStartTime,
+                eventUTCEndTime: eventUTCStartTime + 86400000
+            })
         }
         return occurences
     }

--- a/src/calendar.service.ts
+++ b/src/calendar.service.ts
@@ -193,7 +193,7 @@ export class CalendarService {
             let eventUTCStartTime = Date.UTC(matchDate.getFullYear(), matchDate.getMonth(), matchDate.getDate())
             occurences.push({
                 eventUTCStartTime: eventUTCStartTime,
-                eventUTCEndTime: eventUTCStartTime + 86400000
+                eventUTCEndTime: eventUTCStartTime + 86399999
             })
         }
         return occurences


### PR DESCRIPTION
moment-recur-ts is used to calculate the recurring events. 
The IEvent model has been extended by 3 attributes: 

- **rruleFreq**: Rule.MeasureInput It can be days, weeks, months, daysOfWeek, monthsOfYear 

- **rruleInterval**: Rule.UnitsInput:
        It can be a number: every N days or every N weeks.
        It can be an array of numbers [2,3]
        It can be an array of strings ['mon','wed']
        See more in https://jefbarn.github.io/moment-recur-ts/

- **rruleUntil**: Date The last date the event is recurring.

A new function getEventOccurences has been introduced in CalendarServices. This returns all occurrences of an event in the period between utcStartTime and utcEndTime

The onDataLoaded function has been adapted in dayview weekview and monthview so that they use the getEventOccurences function.